### PR TITLE
ci: update GitHub actions from scheduled version check

### DIFF
--- a/.github/config/megalinter.yaml
+++ b/.github/config/megalinter.yaml
@@ -71,13 +71,6 @@ DISABLE_LINTERS:
 # ------------------------
 
 # ------------------------
-# Fix Errors
-
-# Automatically update files with corrections
-APPLY_FIXES: all # all, none, or list of linter keys
-# ------------------------
-
-# ------------------------
 # Reporting
 
 # Activate sources reporter

--- a/.github/workflows/megalinter.yaml
+++ b/.github/workflows/megalinter.yaml
@@ -9,13 +9,12 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
 
-env:
-  # Apply linter fixes configuration
-  APPLY_FIXES: all # APPLY_FIXES must be defined as environment variable
-  APPLY_FIXES_EVENT: pull_request # events that trigger fixes on a commit or PR (pull_request, push, all)
-  APPLY_FIXES_MODE: pull_request # are fixes are directly committed (commit) or posted in a PR (pull_request)
+# env:
+#   # Apply linter fixes configuration
+#   APPLY_FIXES: all # APPLY_FIXES must be defined as environment variable
+#   APPLY_FIXES_EVENT: pull_request # events that trigger fixes on a commit or PR (pull_request, push, all)
+#   APPLY_FIXES_MODE: commit # are fixes are directly committed (commit) or posted in a PR (pull_request)
 
 # Run Linters in parallel
 # Cancel running job if new job is triggered
@@ -77,7 +76,7 @@ jobs:
       - name: Create Pull Request with applied fixes
         id: cpr
         if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           commit-message: "[MegaLinter] Apply linters automatic fixes"

--- a/.github/workflows/quality-checks.yaml
+++ b/.github/workflows/quality-checks.yaml
@@ -34,7 +34,7 @@ jobs:
           restore-keys: clojure-deps-
 
       - name: "Install tools"
-        uses: DeLaGuardo/setup-clojure@10.2
+        uses: DeLaGuardo/setup-clojure@10.3
         with:
           cli: 1.11.1.1273 # Clojure CLI
           cljstyle: 0.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+- ci: update MegaLinter and Quality check actions to latest versions
+
 ### Changed
 
 ## 0.1.0 - 2023-04-20


### PR DESCRIPTION
📓 Description

Update GitHub workflows to use latest GitHub action version, as identified by the Scheduled Version Check workflow

https://github.com/jcpsantiago/thearqivist/actions/runs/4815841487

- peter-evans/create-pull-request@v5
- DeLaGuardo/setup-clojure@10.3

NOTE: setup-clojure does not seem to find the latest point version when only
using the major version, so 10.3 is required rather than 10

:octocat Type of change

- [ ] New feature
- [ ] Deprecate feature
- [ ] Development workflow
- [ ] Documentation
- [x] Continuous integration workflow

:beetle How Has This Been Tested?

- [ ] unit test
- [ ] linter check
- [x] GitHub Action checkers

:eyes Checklist

- [x] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [x] Add / update alias docs and README where relevant
- [ ] Changelog entry describing notable changes
- [x] Request maintainers review the PR