### PR TITLE
ci: remove redundant antq run, monthly schedule

### DIFF
--- a/.github/workflows/scheduled-version-check.yaml
+++ b/.github/workflows/scheduled-version-check.yaml
@@ -12,7 +12,9 @@
 name: "Scheduled Version Check"
 on:
   schedule:
-    - cron: "0 4 * * *" # at 04:04:04 ever day
+    # - cron: "0 4 * * *" # at 04:04:04 ever day
+    # - cron: "0 4 * * 5" # at 04:04:04 ever Friday
+    - cron: "0 4 1 * *" # at 04:04:04 on first day of month
   workflow_dispatch: # Run manually via GitHub Actions Workflow page
 
 jobs:
@@ -30,9 +32,6 @@ jobs:
 
       - name: "Setup Antq"
         uses: liquidz/antq-action@main
-
-      - name: "Antq Check versions"
-        run: antq --error-format="::error file={{file}}::{{message}}"
 
       - run: echo "🎨 library versions checked with liquidz/antq"
 


### PR DESCRIPTION
📓 Description

liquidz/antq-action runs the antq command, so a separate job is not required

Set schedule to 1st of month

:octocat Type of change

_Please tick `x` relevant options, delete those not relevant_

- [ ] New feature
- [ ] Deprecate feature
- [ ] Development workflow
- [ ] Documentation
- [x] Continuous integration workflow

:beetle How Has This Been Tested?

- [ ] unit test
- [ ] linter check
- [x] GitHub Action checkers

:eyes Checklist

- [ ] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [ ] Add / update alias docs and README where relevant
- [ ] Changelog entry describing notable changes
- [x] Request maintainers review the PR
