### PR TITLE
Add first MKDocs pages using Material

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,0 +1,24 @@
+name: mkdocs
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+      - uses: actions/cache@v3
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install mkdocs-material 
+      - run: mkdocs gh-deploy --force

--- a/docs/atlassian.md
+++ b/docs/atlassian.md
@@ -1,0 +1,13 @@
+# Atlassian's Confluence API
+
+The Confluence has a lot of undocumented behavior,
+with info scattered across blog posts and forum answers.
+
+This page documents some of the relevant quirks to develop The Arqivist.
+
+## Application descriptor
+
+Confluence uses this JSON file to install apps.
+It contains identifying information about the app itself,
+and other pieces of configuration such as url endpoints and custom key-value pairs to save in each page's cache.
+

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -1,0 +1,7 @@
+# Development
+
+These are instructions on how to hack on The Arqivist locally.
+
+## Requirements
+
+* Clojure 1.11+

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,1 @@
+# Getting started

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,30 @@
+# Introduction
+
+<figure>
+    <img src="https://arqivist.app/img/arqivist.jpg"
+         alt="The Arqivist's logo is a medieval scribe working on a document"
+	 width=200
+    	 height=200>
+    <figcaption>The Arqivist hard at work</figcaption>
+</figure>
+
+The Arqivist is an app integrating Confluence and Slack,
+letting you create pages from Slack messages,
+It can also backup messages and files to Google Drive (more soon), either once or continuously on a schedule.
+
+## Use-cases
+
+* **Creating ad-hoc documentation** — No docs? No problem! Ask in Slack and then create a Confluence page with the answer!
+* **Incident management** — Create a dedicated channel for an incident, and save the whole discussion for future reference.
+* **Disaster recovery** — Make Slack part of your disaster-recovery strategy, and backup the contents of critical channels.
+
+## Motivation
+
+A lot of critical knowledge is created and shared on Slack channels.
+However, no one is in all channels, nor has the time to read them.
+We were missing a way to curate important discussions,
+and preserve them.
+Conversations saved outside Slack,
+could be linked and referenced in other docs and tickets.
+This, in turn, would make them more visible and consequential.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,8 @@ The Arqivist is an app integrating Confluence and Slack,
 letting you create pages from Slack messages,
 It can also backup messages and files to Google Drive (more soon), either once or continuously on a schedule.
 
+You can try The Arqivist for free at the [Atlassian marketplace](https://marketplace.atlassian.com/apps/1227973), or look at the source code at [jcpsantiago/thearqivist](https://github.com/jcpsantiago/thearqivist).
+
 ## Use-cases
 
 * **Creating ad-hoc documentation** — No docs? No problem! Ask in Slack and then create a Confluence page with the answer!

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -7,21 +7,40 @@ sequenceDiagram
     participant S as Slack
     participant A as The Arqivist
     participant C as Confluence
-    U->>S: Interaction
-    S->>A: Call matching endpoint
+    U->>S: Interaction<br>(shortcut or slash)
+    Note left of U: user is waiting
+    S->>+A: Call matching endpoint
     A->>S: Respond 200 immediately
+    Note over S,A: start checks<br>(depends on endpoint)
+    A->A: Is message part of a thread?
+    break message is not in a thread
+        A-)U: Inform user that shortcuts only work in threads
+    end
     A-)S: GET channel.info
+    break channel is private
+        A-)U: Ask user to invite the bot
+    end
     A-)S: GET conversation.members
+    opt bot is not member of channel
+        A-)S: POST conversations.join
+    end
     A-)C: CQL query for channel_id
+    opt thread or channel is already in Confluence
+        A-)U: Ask user if it's ok to overwrite existing page
+    end
+    Note over S,A: end checks
     A-)U: Show modal confirming action/requesting more info
-    A--)S: GET conversation.history
+    Note left of U: sees modal
+    A--)S: GET conversation.history (`ch`)
     U->>S: Confirm
+    Note left of U: user is waiting
     S->>A: Call view_submission endpoint
-    loop For every message
+    loop For reply in `ch`
         A->>S: GET user.info
     end
     A->>C: Create page
-    A->>U: Feedback
+    A->>-U: Feedback
+    Note left of U: user sees feedback, end
 ```
 
 ## Interacting with Slack

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1,5 +1,9 @@
 # Internals
 
+This page describes how the app works.
+
+## Actions in sequence
+
 ```mermaid
 sequenceDiagram
     autonumber
@@ -11,7 +15,7 @@ sequenceDiagram
     Note left of U: user is waiting
     S->>+A: Call matching endpoint
     A->>S: Respond 200 immediately
-    Note over S,A: start checks<br>(depends on endpoint)
+    Note over S,A: start contingency checks<br>(depends on endpoint)
     A->A: Is message part of a thread?
     break message is not in a thread
         A-)U: Inform user that shortcuts only work in threads
@@ -28,7 +32,7 @@ sequenceDiagram
     opt thread or channel is already in Confluence
         A-)U: Ask user if it's ok to overwrite existing page
     end
-    Note over S,A: end checks
+    Note over S,A: end contingency checks
     A-)U: Show modal confirming action/requesting more info
     Note left of U: sees modal
     A--)S: GET conversation.history (`ch`)
@@ -45,12 +49,31 @@ sequenceDiagram
 
 ## Interacting with Slack
 
-There are two main ways to use the bot in Slack:
+There are two ways to use the bot in Slack:
 
-* [Message shortcut :octicons-link-external-16:](https://api.slack.com/interactivity/shortcuts/using#message_shortcuts)
-* [Slash command :octicons-link-external-16:](https://api.slack.com/interactivity/slash-commands) 
+* Via a [message shortcut :octicons-link-external-16:](https://api.slack.com/interactivity/shortcuts/using#message_shortcuts)
+* Via the `/arqive` [slash command :octicons-link-external-16:](https://api.slack.com/interactivity/slash-commands) 
 
-### Message shortcut
+The message shortcut is present in the "More actions" or "three dots" button of each message.
+At the moment this method is only used for archiving message threads,
+because it's not possible to use slash commands within a thread.
 
+Users can add arbitrary text to a slash commands, which makes them more flexible.
 
-### Slash command
+* `/arqive help`       shows a message explaining how to use the bot, which actions are available, etc.
+* `/arqive`            prompts the archival of the current channel _once_
+* `/arqive [schedule]` prompts the _continuous_ archival of the current channel (WIP)
+
+Each of them will target a different endpoint in the app, namely `/slack/shortcut` and `/slack/slash`.
+
+Regardless of the endpoint, or use-case, some conditions must be met in order for the bot to work properly.
+We call these `contingencies` internally, and they are checked on each request:
+
+* is the origin of the request a message thread? (used for the shorcut)
+* is the channel private?
+* is The Arqivist a member of the channel?
+* is the current `target` already in Confluence?
+
+If all conditions are met, the user will see a modal for final confirmation of their action.
+Otherwise, they will receive a modal informing them that something is wrong,
+and they must take some action e.g. invite The Arqivist into the channel manually.

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1,0 +1,37 @@
+# Internals
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User
+    participant S as Slack
+    participant A as The Arqivist
+    participant C as Confluence
+    U->>S: Interaction
+    S->>A: Call matching endpoint
+    A->>S: Respond 200 immediately
+    A-)S: GET channel.info
+    A-)S: GET conversation.members
+    A-)C: CQL query for channel_id
+    A-)U: Show modal confirming action/requesting more info
+    A--)S: GET conversation.history
+    U->>S: Confirm
+    S->>A: Call view_submission endpoint
+    loop For every message
+        A->>S: GET user.info
+    end
+    A->>C: Create page
+    A->>U: Feedback
+```
+
+## Interacting with Slack
+
+There are two main ways to use the bot in Slack:
+
+* [Message shortcut :octicons-link-external-16:](https://api.slack.com/interactivity/shortcuts/using#message_shortcuts)
+* [Slash command :octicons-link-external-16:](https://api.slack.com/interactivity/slash-commands) 
+
+### Message shortcut
+
+
+### Slash command

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,4 @@
+site_name: The Arqivist docs 
+theme:
+  name: material
+repo_url: https://github.com/jcpsantiago/thearqivist

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,14 @@
 site_name: The Arqivist docs 
 theme:
   name: material
+markdown_extensions:
+  - attr_list
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
 repo_url: https://github.com/jcpsantiago/thearqivist


### PR DESCRIPTION
📓 Description

_Summary of the change and link to any relevant tickets. New aliases should include details of why they are valuable_

Adds MKDocs for documentation, which we'll use instead of Github's wiki.

:octocat: Type of change

_Please tick `x` relevant options, delete those not relevant_

- [ ] New feature
- [ ] Deprecate feature
- [ ] Development workflow
- [x] Documentation
- [ ] Continuous integration workflow

:beetle: How Has This Been Tested?

- [ ] unit test
- [ ] linter check
- [x] GitHub Action checkers

:eyes: Checklist

- [ ] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [x] Add / update alias docs and README where relevant
- [ ] Changelog entry describing notable changes
- [ ] Request maintainers review the PR (skipped)
