### PR TITLE
Add contributors to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ After installing The Arqivist in Slack, you can interact with the bot in two way
 * Start a REPL with `make repl`
 * Start the system with `(start)` in the Clojure REPL
 * `make lint` to check for format and lint issue, `make lint-fix` to automatically fix them (stage or commit other changes first) - requires node.js locally
+  
+## Contributors
+
+[![](https://contrib.rocks/image?repo=jcpsantiago/thearqivist)](https://github.com/jcpsantiago/thearqivist/graphs/contributors)
 
 ## Contributing
 
@@ -51,4 +55,4 @@ If you found a bug, or want to propose new features please open an issue. PRs ar
 
 ## License
 
-MIT
+MIT 


### PR DESCRIPTION
📓 Description

_Summary of the change and link to any relevant tickets. New aliases should include details of why they are valuable_

Adds the avatars of the contributors in repo to the README file.

:octocat: Type of change

_Please tick `x` relevant options, delete those not relevant_

- [X] Documentation

:beetle: How Has This Been Tested?

- [ ] unit test
- [ ] linter check
- [x] GitHub Action checkers

:eyes: Checklist

- [ ] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [ ] Add / update alias docs and README where relevant
- [ ] Changelog entry describing notable changes
- [ ] Request maintainers review the PR
