### PR TITLE
Verify JWT token in Atlassian lifecycle (installed/uninstalled) events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Use donut.system to create a system, enable REPL-driven development [#5](https://github.com/jcpsantiago/thearqivist/issues/5)
 * Added scaffolding for routes using reitit
 * dev: add `lint-fix` Makefile task to automatically apply changes from MegaLinter
+* [#34](https://github.com/jcpsantiago/thearqivist/issues/34) Add middleware to verify Atlassian lifecycle event requests
 
 ## 0.1.0 - 2023-04-20
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ After installing The Arqivist in Slack, you can interact with the bot in two way
 * Start a REPL with `make repl`
 * Start the system with `(start)` in the Clojure REPL
 * `make lint` to check for format and lint issue, `make lint-fix` to automatically fix them (stage or commit other changes first) - requires node.js locally
-  
+
 ## Contributors
 
 [![](https://contrib.rocks/image?repo=jcpsantiago/thearqivist)](https://github.com/jcpsantiago/thearqivist/graphs/contributors)
@@ -55,4 +55,4 @@ If you found a bug, or want to propose new features please open an issue. PRs ar
 
 ## License
 
-MIT 
+MIT

--- a/src/jcpsantiago/arqivist/api/confluence/router.clj
+++ b/src/jcpsantiago/arqivist/api/confluence/router.clj
@@ -1,5 +1,7 @@
 (ns jcpsantiago.arqivist.api.confluence.router
-  "Reitit routes for interacting with Confluence.")
+  "Reitit routes for interacting with Confluence."
+  (:require
+   [jcpsantiago.arqivist.middleware :as middleware-arqivist]))
 
 (defn routes
   "Routes used by Confluence:
@@ -26,7 +28,8 @@
       :handler {:status 200 :body "HELLO!"}}}]
 
    ["/installed"
-    {:post
+    {:middleware [[middleware-arqivist/verify-atlassian-lifecycle :verify-atlassian-jwt]]
+     :post
      {:summary "Webhook for the 'install' event"
       :description "Webhook for the `install` event<br>
                     Triggered in various events, but the most important is the initial app installation to a site.<br>
@@ -44,7 +47,8 @@
       :handler {:status 200 :body "HELLO!"}}}]
 
    ["/uninstalled"
-    {:post
+    {:middleware [[middleware-arqivist/verify-atlassian-lifecycle :verify-atlassian-jwt]]
+     :post
      {:summary "Webhook for the 'uninstall' event"
       :description "Webhook for the `uninstall` event when a user uninstalls the app from a site."
       :responses {200 {:body string?}}

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -36,7 +36,7 @@
 (defn verify-atlassian-lifecycle
   "Middleware to verify the JWT token present in
   Atlassian lifecycle installed/uninstalled events."
-  [handler id]
+  [handler _]
   (fn [request]
     (let [jwt-token (-> (or (get-in request [:headers "authorization"]) "")
                         (string/replace #"JWT\s" ""))]
@@ -56,4 +56,3 @@
                      :local-time (java.time.LocalDateTime/now))
           ;; Atlassian only fails on 500, all other statuses will be seen as "OK"
           {:status 500 :body ""})))))
-

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -1,6 +1,10 @@
 (ns jcpsantiago.arqivist.middleware
   "Extra ring middleware"
   (:require
+   [buddy.core.keys :as keys]
+   [buddy.sign.jws :as jws]
+   [buddy.sign.jwt :as jwt]
+   [clojure.string :as string]
    [com.brunobonacci.mulog :as mulog]))
 
 ;; Slack middleware
@@ -17,14 +21,39 @@
      {:uri            (get request :uri)
       :request-method (get request :request-method)}
 
-     ;; track the request duration and outcome
-     (mulog/trace :io.redefine.datawarp/http-request
-                  ;; add key/value pairs for tracking event only
-                  {:pairs [:content-type     (get-in request [:headers "content-type"])
-                           :content-encoding (get-in request [:headers "content-encoding"])
-                           :middleware       id]
-                   ;; capture http status code from the response
-                   :capture (fn [{:keys [status]}] {:http-status status})}
+      ;; track the request duration and outcome
+      (mulog/trace :io.redefine.datawarp/http-request
+        ;; add key/value pairs for tracking event only
+        {:pairs [:content-type     (get-in request [:headers "content-type"])
+                 :content-encoding (get-in request [:headers "content-encoding"])
+                 :middleware       id]
+         ;; capture http status code from the response
+         :capture (fn [{:keys [status]}] {:http-status status})}
 
-                  ;; call the request handler
-                  (handler request)))))
+        ;; call the request handler
+        (handler request)))))
+
+(defn verify-atlassian-lifecycle
+  "Middleware to verify the JWT token present in
+  Atlassian lifecycle installed/uninstalled events."
+  [handler id]
+  (fn [request]
+    (let [jwt-token (-> (or (get-in request [:headers "authorization"]) "")
+                        (string/replace #"JWT\s" ""))]
+      (try
+        (let [jwt-header (jws/decode-header jwt-token)
+              public-key (keys/public-key (str "https://connect-install-keys.atlassian.com/" (:kid jwt-header)))
+              _ (jwt/unsign jwt-token public-key {:alg (:alg jwt-header)})]
+          (mulog/log ::verifying-atlassian-lifecycle-event
+                     :success :true
+                     :local-time (java.time.LocalDateTime/now))
+          (handler request))
+
+        (catch Exception e
+          (mulog/log ::verifying-atlassian-lifecycle-event
+                     :success :false
+                     :error (.getMessage e)
+                     :local-time (java.time.LocalDateTime/now))
+          ;; Atlassian only fails on 500, all other statuses will be seen as "OK"
+          {:status 500 :body ""})))))
+

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -21,17 +21,17 @@
      {:uri            (get request :uri)
       :request-method (get request :request-method)}
 
-      ;; track the request duration and outcome
-      (mulog/trace :io.redefine.datawarp/http-request
-        ;; add key/value pairs for tracking event only
-        {:pairs [:content-type     (get-in request [:headers "content-type"])
-                 :content-encoding (get-in request [:headers "content-encoding"])
-                 :middleware       id]
-         ;; capture http status code from the response
-         :capture (fn [{:keys [status]}] {:http-status status})}
+     ;; track the request duration and outcome
+     (mulog/trace :io.redefine.datawarp/http-request
+                  ;; add key/value pairs for tracking event only
+                  {:pairs [:content-type     (get-in request [:headers "content-type"])
+                           :content-encoding (get-in request [:headers "content-encoding"])
+                           :middleware       id]
+                   ;; capture http status code from the response
+                   :capture (fn [{:keys [status]}] {:http-status status})}
 
-        ;; call the request handler
-        (handler request)))))
+                  ;; call the request handler
+                  (handler request)))))
 
 (defn verify-atlassian-lifecycle
   "Middleware to verify the JWT token present in


### PR DESCRIPTION
📓 Description

_Summary of the change and link to any relevant tickets. New aliases should include details of why they are valuable_

This PR adds a new middleware called `verify-atlassian-lifecycle` which attempts to unsign the JWT token sent in the header of Atlassian lifecycle requests (installed/uninstalled). If it can successfully decode the JWT token, it moves on, otherwise responds to the request with HTTP 500.

Verifying requests increases the safety of the app, and follows recommended best-practices by Atlassian.

Resolve #34 

:octocat: Type of change

_Please tick `x` relevant options, delete those not relevant_

- [x] New feature

:beetle: How Has This Been Tested?

- [ ] unit test
- [x] linter check
- [x] GitHub Action checkers

:eyes: Checklist

- [x] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [ ] Add / update alias docs and README where relevant
- [x] Changelog entry describing notable changes
- [x] Request maintainers review the PR
