### PR TITLE
Add slack verification middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#30](https://github.com/jcpsantiago/thearqivist/issues/30) Add atlassian lifecycle endpoints
 * [#34](https://github.com/jcpsantiago/thearqivist/issues/34) Add middleware to verify Atlassian lifecycle event requests
 * [#32](https://github.com/jcpsantiago/thearqivist/issues/32) Add Slack redirect endpoint
-
+* [#35](https://github.com/jcpsantiago/thearqivist/issues/35) Add Slack request verification middleware
+ 
 ## 0.1.0 - 2023-04-20
 
 ### Added

--- a/src/jcpsantiago/arqivist/api/slack/router.clj
+++ b/src/jcpsantiago/arqivist/api/slack/router.clj
@@ -1,6 +1,7 @@
 (ns jcpsantiago.arqivist.api.slack.router
   "Reitit routes for interacting with Slack."
   (:require
+   [jcpsantiago.arqivist.middleware :as middleware-arqivist]
    [jcpsantiago.arqivist.api.slack.handlers :as handlers]
    [jcpsantiago.arqivist.api.slack.specs :as specs]))
 
@@ -10,41 +11,44 @@
    * slash    — triggered after the user uses the `/arqive` slash command
    * redirect — called as part of the OAuth process at the end of installation"
   [system]
-  ["/slack"
-   {:swagger {:tags ["Slack"]}}
-   ["/shortcut"
-    {:swagger {:externalDocs
-               {:description "Slack docs about Message Shortcuts"
-                :url "https://api.slack.com/interactivity/shortcuts/using#message_shortcuts"}}
-     :post
-     {:summary "Target for Message Shortcut interactions"
-      :description "This endpoint receives all interactions initiated by clicking the Message Shortcut button. It also receives all follow-up interactions with the use via modals."
+  (let [wrap-verify-slack-request (partial middleware-arqivist/wrap-verify-slack-request (:slack-env system))]
+    ["/slack"
+     {:swagger {:tags ["Slack"]}}
+     ["/shortcut"
+      {:swagger {:externalDocs
+                 {:description "Slack docs about Message Shortcuts"
+                  :url "https://api.slack.com/interactivity/shortcuts/using#message_shortcuts"}}
+       :middleware [[wrap-verify-slack-request :verify-slack-request]]
+       :post
+       {:summary "Target for Message Shortcut interactions"
+        :description "This endpoint receives all interactions initiated by clicking the Message Shortcut button. It also receives all follow-up interactions with the use via modals."
       ;; TODO: add the rest of the specs, not working yet
       ;; :parameters {:body :jcpsantiago.arqivist.api.slack.spec/shortcut-body}
-      :responses {200 {:body string?}}
-      :handler handlers/message-shortcut}}]
+        :responses {200 {:body string?}}
+        :handler handlers/message-shortcut}}]
 
    ;; TODO: Add example from https://api.slack.com/interactivity/slash-commands#app_command_handling
-   ["/slash"
-    {:swagger {:externalDocs
-               {:description "Slack docs about Slash Commands"
-                :url "https://api.slack.com/interactivity/slash-commands"}}
-     :post
-     {:summary "Target for Slash Command interactions"
-      :description "This endpoint receives all interactions initiated by typing the `/arqive` slash command."
+     ["/slash"
+      {:swagger {:externalDocs
+                 {:description "Slack docs about Slash Commands"
+                  :url "https://api.slack.com/interactivity/slash-commands"}}
+       :middleware [[wrap-verify-slack-request :verify-slack-request]]
+       :post
+       {:summary "Target for Slash Command interactions"
+        :description "This endpoint receives all interactions initiated by typing the `/arqive` slash command."
       ;; TODO: add the rest of the specs, not working yet
       ;; :parameters {:form :jcpsantiago.arqivist.api.slack.spec/slash-form-params}
-      :responses {200 {:body string?}}
-      :handler handlers/slash-command}}]
+        :responses {200 {:body string?}}
+        :handler handlers/slash-command}}]
 
-   ["/redirect"
-    {:swagger {:externalDocs
-               {:description "Slack OAuthV2 docs"
-                :url "https://api.slack.com/authentication/oauth-v2"}}
-     :get
-     {:summary "OAuth2 redirect target"
-      :description "This endpoint receives the data about the workspace, after a user successfully added the app to their account."
-      :parameters {:query ::specs/oauth-redirect}
-      :responses {200 {:body string?}
-                  500 {:body string?}}
-      :handler (handlers/oauth-redirect system)}}]])
+     ["/redirect"
+      {:swagger {:externalDocs
+                 {:description "Slack OAuthV2 docs"
+                  :url "https://api.slack.com/authentication/oauth-v2"}}
+       :get
+       {:summary "OAuth2 redirect target"
+        :description "This endpoint receives the data about the workspace, after a user successfully added the app to their account."
+        :parameters {:query ::specs/oauth-redirect}
+        :responses {200 {:body string?}
+                    500 {:body string?}}
+        :handler (handlers/oauth-redirect system)}}]]))

--- a/src/jcpsantiago/arqivist/api/slack/router.clj
+++ b/src/jcpsantiago/arqivist/api/slack/router.clj
@@ -22,12 +22,12 @@
        :post
        {:summary "Target for Message Shortcut interactions"
         :description "This endpoint receives all interactions initiated by clicking the Message Shortcut button. It also receives all follow-up interactions with the use via modals."
-      ;; TODO: add the rest of the specs, not working yet
-      ;; :parameters {:body :jcpsantiago.arqivist.api.slack.spec/shortcut-body}
+        ;; TODO: add the rest of the specs, not working yet
+        ;; :parameters {:body :jcpsantiago.arqivist.api.slack.spec/shortcut-body}
         :responses {200 {:body string?}}
         :handler handlers/message-shortcut}}]
 
-   ;; TODO: Add example from https://api.slack.com/interactivity/slash-commands#app_command_handling
+     ;; TODO: Add example from https://api.slack.com/interactivity/slash-commands#app_command_handling
      ["/slash"
       {:swagger {:externalDocs
                  {:description "Slack docs about Slash Commands"
@@ -36,8 +36,8 @@
        :post
        {:summary "Target for Slash Command interactions"
         :description "This endpoint receives all interactions initiated by typing the `/arqive` slash command."
-      ;; TODO: add the rest of the specs, not working yet
-      ;; :parameters {:form :jcpsantiago.arqivist.api.slack.spec/slash-form-params}
+        ;; TODO: add the rest of the specs, not working yet
+        ;; :parameters {:form :jcpsantiago.arqivist.api.slack.spec/slash-form-params}
         :responses {200 {:body string?}}
         :handler handlers/slash-command}}]
 

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -85,16 +85,16 @@
       :request-method (get request :request-method)}
 
      ;; track the request duration and outcome
-      (mulog/trace :io.redefine.datawarp/http-request
+     (mulog/trace :io.redefine.datawarp/http-request
                   ;; add key/value pairs for tracking event only
-        {:pairs [:content-type     (get-in request [:headers "content-type"])
-                 :content-encoding (get-in request [:headers "content-encoding"])
-                 :middleware       id]
+                  {:pairs [:content-type     (get-in request [:headers "content-type"])
+                           :content-encoding (get-in request [:headers "content-encoding"])
+                           :middleware       id]
                    ;; capture http status code from the response
-         :capture (fn [{:keys [status]}] {:http-status status})}
+                   :capture (fn [{:keys [status]}] {:http-status status})}
 
                   ;; call the request handler
-        (handler request)))))
+                  (handler request)))))
 
 ;; Atlassian middleware -----------------------------------------------------
 (defn verify-atlassian-lifecycle

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -1,16 +1,79 @@
 (ns jcpsantiago.arqivist.middleware
   "Extra ring middleware"
   (:require
+   [buddy.core.codecs :as codecs]
+   [buddy.core.mac :as mac]
    [buddy.core.keys :as keys]
    [buddy.sign.jws :as jws]
    [buddy.sign.jwt :as jwt]
    [clojure.string :as string]
+   [clojure.walk :refer [keywordize-keys]]
    [com.brunobonacci.mulog :as mulog]))
 
-;; Slack middleware
-;; TODO: Add middleware for verifying if the request is from Slack
+;; Slack middleware ----------------------------------------------------------
+(defn wrap-keep-raw-json-string
+  "Middleware that slurps the bytestream in the :body of a request,
+   updating it with the unparsed, uncoerced json string.
+   Needed to verify Slack requests."
+  [handler id]
+  (fn [request]
+    (mulog/log ::keeping-raw-json-string :middleware-id id :uri (:uri request) :local-time (java.time.LocalDateTime/now))
+    (handler (update request :body slurp))))
 
-;; Logging middleware
+(defn from-slack?
+  "Verifies if the request really came from Slack.
+  https://api.slack.com/authentication/verifying-requests-from-slack"
+  [slack-env timestamp payload slack-signature]
+  (try
+    (mac/verify (str "v0:" timestamp ":" payload)
+                (codecs/hex->bytes slack-signature)
+                {:key (:arqivist-slack-signing-secret slack-env) :alg :hmac+sha256})
+    (catch
+     Exception e
+      (mulog/log ::verify-mac-hash
+                 :success :false
+                 :error (.getMessage e)
+                 :local-time (java.time.LocalDateTime/now)))))
+
+(defn wrap-verify-slack-request
+  "Ring middleware to verify the authenticity of requests
+   hitting the Slack endpoints.
+   See official docs https://api.slack.com/authentication/verifying-requests-from-slack"
+  [slack-env handler id]
+  (fn [request]
+    (let [keywordized-headers (keywordize-keys (:headers request))]
+      (if (every? #(contains? keywordized-headers %) [:x-slack-request-timestamp :x-slack-signature])
+        (let [{:keys [x-slack-signature x-slack-request-timestamp]} keywordized-headers
+              slack-signature (string/replace x-slack-signature #"v0=" "")
+              slack-request?  (from-slack? slack-env
+                                           x-slack-request-timestamp
+                                           (:body request)
+                                           slack-signature)]
+          (if slack-request?
+            (do
+              (mulog/log ::verify-slack-request
+                         :middleware-id id
+                         :success :true
+                         :local-time (java.time.LocalDateTime/now))
+              (handler request))
+            ;; else if request is invalid
+            (do
+              (mulog/log ::verify-slack-request
+                         :middleware-id id
+                         :success :false
+                         :error "The request is not from slack"
+                         :local-time (java.time.LocalDateTime/now))
+              {:status 403, :body "Invalid credentials provided"})))
+        ;; else if headers are missing
+        (do
+          (mulog/log ::verify-slack-request
+                     :middleware-id id
+                     :success :false
+                     :error "The necessary headers are missing"
+                     :local-time (java.time.LocalDateTime/now))
+          {:status 403 :body "Invalid credentials provided"})))))
+
+;; Logging middleware -----------------------------------------------------
 ;; https://github.com/BrunoBonacci/mulog/blob/master/doc/ring-tracking.md
 (defn wrap-trace-events
   "Log event trace for each api event with mulog/log."
@@ -22,17 +85,18 @@
       :request-method (get request :request-method)}
 
      ;; track the request duration and outcome
-     (mulog/trace :io.redefine.datawarp/http-request
+      (mulog/trace :io.redefine.datawarp/http-request
                   ;; add key/value pairs for tracking event only
-                  {:pairs [:content-type     (get-in request [:headers "content-type"])
-                           :content-encoding (get-in request [:headers "content-encoding"])
-                           :middleware       id]
+        {:pairs [:content-type     (get-in request [:headers "content-type"])
+                 :content-encoding (get-in request [:headers "content-encoding"])
+                 :middleware       id]
                    ;; capture http status code from the response
-                   :capture (fn [{:keys [status]}] {:http-status status})}
+         :capture (fn [{:keys [status]}] {:http-status status})}
 
                   ;; call the request handler
-                  (handler request)))))
+        (handler request)))))
 
+;; Atlassian middleware -----------------------------------------------------
 (defn verify-atlassian-lifecycle
   "Middleware to verify the JWT token present in
   Atlassian lifecycle installed/uninstalled events."

--- a/src/jcpsantiago/arqivist/router.clj
+++ b/src/jcpsantiago/arqivist/router.clj
@@ -58,6 +58,9 @@
           ;; TODO: Add middleware for Slack security checks
           :middleware [;; swagger feature for OpenAPI documentation
                        api-docs/swagger-feature
+                       ;; keeps raw json string, needed to verify Slack requests
+                       ;; TODO: only run the middleware when needed
+                       [middleware-arqivist/wrap-keep-raw-json-string :keep-raw-json]
                        ;; query-params & form-params
                        parameters/parameters-middleware
                        ;; content-negotiation


### PR DESCRIPTION
📓 Description

_Summary of the change and link to any relevant tickets. New aliases should include details of why they are valuable_

Resolve #35

This PR adds middleware to verify Slack messages are _really_ from Slack using the HMAC SHA256 algorithm. The official docs are in https://api.slack.com/authentication/verifying-requests-from-slack. To achieve this, I'm `slurp`ing the payload body of every request and `update`ing the body with this value — this is not necessary for all the endpoints, but it's a lighter  (one line) solution to implement than re-reading bytestreams.

The `/slack/shortcut` and `/slack/slash` endpoints are protected with the verification middleware.

:octocat: Type of change

_Please tick `x` relevant options, delete those not relevant_

- [x] New feature

:beetle: How Has This Been Tested?

- [ ] unit test
- [x] linter check
- [x] GitHub Action checkers

Plus some test requests using Postman, didn't test the "happy path" yet, only the 403 failures.

:eyes: Checklist

- [x] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [ ] Add / update alias docs and README where relevant
- [x] Changelog entry describing notable changes
- [x] Request maintainers review the PR
