### PR TITLE
Streamline slack verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Refactor PR #38, improve readability of Slack middleware
 * dev: refactor user namespace removing reloading of mulog publisher and portal
 * [#43](https://github.com/jcpsantiago/thearqivist/issues/43) Add Confluence Get started page
+* dev: refactor slack verification middleware to keep the original body, plus parse header parameters
 
 ## 0.1.0 - 2023-04-20
 

--- a/src/jcpsantiago/arqivist/api/slack/router.clj
+++ b/src/jcpsantiago/arqivist/api/slack/router.clj
@@ -36,8 +36,8 @@
        :post
        {:summary "Target for Slash Command interactions"
         :description "This endpoint receives all interactions initiated by typing the `/arqive` slash command."
-        ;; TODO: add the rest of the specs, not working yet
-        ;; :parameters {:form :jcpsantiago.arqivist.api.slack.spec/slash-form-params}
+        :parameters {:header ::specs/request-header-attributes
+                     :form ::specs/slash-form-params}
         :responses {200 {:body string?}}
         :handler handlers/slash-command}}]
 

--- a/src/jcpsantiago/arqivist/api/slack/specs.clj
+++ b/src/jcpsantiago/arqivist/api/slack/specs.clj
@@ -103,6 +103,16 @@
   (spec/keys
    :req-un [::type ::team ::user ::view]))
 
+
+;; Header parameters -------------------------------------------------------
+;; Used to verify Slack requests
+(spec/def ::x-slack-request-timestamp integer?)
+(spec/def ::x-slack-signature non-blank-string?)
+
+(spec/def ::request-header-attributes
+  (spec/keys
+   :req-un [::x-slack-signature ::x-slack-request-timestamp]))
+
 ;; Internal representations ------------------------------------------------
 (spec/def ::team-attributes
   (spec/keys

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -73,12 +73,6 @@
                      :local-time (java.time.LocalDateTime/now))
           {:status 403 :body "Invalid credentials provided"})))))
 
-(defn wrap-add-slack-team-attributes
-  "
-  Ring middleware to add slack team credentials needed to use the Slack API.
-  Every Slack interaction needs this, except for the /redirect endpoints
-  which is called during installation.
-  "
 ;; Logging middleware -----------------------------------------------------
 ;; https://github.com/BrunoBonacci/mulog/blob/master/doc/ring-tracking.md
 (defn wrap-trace-events

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -6,7 +6,6 @@
    [buddy.core.keys :as keys]
    [buddy.sign.jws :as jws]
    [buddy.sign.jwt :as jwt]
-   [clojure.spec.alpha :as spec]
    [clojure.string :as string]
    [com.brunobonacci.mulog :as mulog]
    [next.jdbc.sql :as sql]

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -8,7 +8,6 @@
    [buddy.sign.jwt :as jwt]
    [clojure.spec.alpha :as spec]
    [clojure.string :as string]
-   [clojure.walk :refer [keywordize-keys]]
    [com.brunobonacci.mulog :as mulog]
    [next.jdbc.sql :as sql]
    [jcpsantiago.arqivist.api.confluence.utils :as utils]))

--- a/test/jcpsantiago/arqivist/middleware_test.clj
+++ b/test/jcpsantiago/arqivist/middleware_test.clj
@@ -1,0 +1,13 @@
+(ns jcpsantiago.arqivist.middleware-test
+  (:require [clojure.test :refer [is deftest testing]]
+            [jcpsantiago.arqivist.middleware :as middleware]))
+
+(deftest from-slack?-test
+  (testing "Computes hash correctly"
+    ;; this example data comes from the official docs https://api.slack.com/authentication/verifying-requests-from-slack
+    ;; NOT PROD CREDENTIALS!
+    (is (true? (middleware/from-slack?
+                "8f742231b10e8888abcd99yyyzzz85a5"
+                1531420618
+                "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"
+                "a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503")))))


### PR DESCRIPTION
📓 Description

_Summary of the change and link to any relevant tickets. New aliases should include details of why they are valuable_

- Parses header parameters to make verification of Slack requests simpler
- Unit tests `from-slack?` according to the official docs
- Keeps the original byte-stream body, in case it's useful downstream

:octocat: Type of change

- [x] New feature

:beetle: How Has This Been Tested?

- [x] unit test
- [x] linter check
- [x] GitHub Action checkers

:eyes: Checklist

- [x] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [ ] Add / update alias docs and README where relevant
- [x] Changelog entry describing notable changes
- [ ] Request maintainers review the PR
