### PR TITLE
Slash command help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * dev: refactor user namespace removing reloading of mulog publisher and portal
 * [#43](https://github.com/jcpsantiago/thearqivist/issues/43) Add Confluence Get started page
 * dev: refactor slack verification middleware to keep the original body, plus parse header parameters
+* [#45](https://github.com/jcpsantiago/thearqivist/issues/45) Add help keyword to slash command
 
 ## 0.1.0 - 2023-04-20
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ WIP
 
 After installing The Arqivist in Slack, you can interact with the bot in two ways
 
-* `/arqive` [slash command](https://api.slack.com/interactivity/slash-commands) — creates a Confluence page with all the messages of the _current channel_
+* `/arqive [keyword]` [slash command](https://api.slack.com/interactivity/slash-commands) is the main point of entry to The Arqivist. It expects one of these keywords:
+ - `help` — show help information with the available keywords, ways of interacting etc.
+
 * [Message shortcut](https://api.slack.com/interactivity/shortcuts/using#message_shortcuts) — creates a Confluence page with all the messages in the _current thread_
 
 

--- a/deps.edn
+++ b/deps.edn
@@ -31,6 +31,9 @@
   metosin/reitit {:mvn/version "0.6.0"}
   metosin/jsonista {:mvn/version "0.3.7"}
 
+  ;; Slack
+  org.julienxx/clj-slack {:mvn/version "0.8.0"}
+
   ;; Webpages
   hiccup/hiccup {:mvn/version "2.0.0-alpha2"}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -32,7 +32,9 @@
   metosin/jsonista {:mvn/version "0.3.7"}
 
   ;; Slack
-  org.julienxx/clj-slack {:mvn/version "0.8.0"}
+  io.github.jcpsantiago/clj-slack {:git/sha "edd8af9" :git/tag "0.8.1"}
+  ;; not using this until they merge the PR updating the OAuth method
+  ;; org.julienxx/clj-slack {:mvn/version "0.8.0"}
 
   ;; Webpages
   hiccup/hiccup {:mvn/version "2.0.0-alpha2"}}

--- a/src/jcpsantiago/arqivist/api/slack/handlers.clj
+++ b/src/jcpsantiago/arqivist/api/slack/handlers.clj
@@ -71,7 +71,7 @@
   See j.a.a.s.specs ns for the request spec. 
   "
   [_]
-  (fn [{{{:keys [text]} :form} :parameters :as request}]
+  (fn [{{{:keys [text]} :form} :parameters}]
     (mulog/log ::handling-slack-slash-command
                :text text
                :local-time (java.time.LocalDateTime/now))

--- a/src/jcpsantiago/arqivist/api/slack/handlers.clj
+++ b/src/jcpsantiago/arqivist/api/slack/handlers.clj
@@ -4,7 +4,6 @@
    [clj-slack.oauth :as clj-slack]
    [clojure.spec.alpha :as spec]
    [com.brunobonacci.mulog :as mulog]
-   [org.httpkit.client :as httpkit]
    [jcpsantiago.arqivist.api.slack.ui-blocks :as ui]
    [jcpsantiago.arqivist.api.slack.pages :as pages]
    [jcpsantiago.arqivist.api.slack.specs :as specs]

--- a/src/jcpsantiago/arqivist/api/slack/handlers.clj
+++ b/src/jcpsantiago/arqivist/api/slack/handlers.clj
@@ -51,9 +51,9 @@
 (defn help-message
   []
   (-> (ui/help-message)
-         json/write-value-as-string
-         response
-         (content-type "application/json")))
+      json/write-value-as-string
+      response
+      (content-type "application/json")))
 
 (defn slash-command
   "Handler function for /slack/slash route"

--- a/src/jcpsantiago/arqivist/api/slack/handlers.clj
+++ b/src/jcpsantiago/arqivist/api/slack/handlers.clj
@@ -4,9 +4,12 @@
    [clj-slack.oauth :as clj-slack]
    [clojure.spec.alpha :as spec]
    [com.brunobonacci.mulog :as mulog]
+   [org.httpkit.client :as httpkit]
+   [jcpsantiago.arqivist.api.slack.ui-blocks :as ui]
    [jcpsantiago.arqivist.api.slack.pages :as pages]
    [jcpsantiago.arqivist.api.slack.specs :as specs]
    [jcpsantiago.arqivist.api.slack.utils :as utils]
+   [jsonista.core :as json]
    [next.jdbc.sql :as sql]
    [ring.util.response :refer [response content-type]]))
 
@@ -45,6 +48,13 @@
 ;; ------------------------------------------------------
 ;; Handlers for Slack Slash commands
 
+(defn help-message
+  []
+  (-> (ui/help-message)
+         json/write-value-as-string
+         response
+         (content-type "application/json")))
+
 (defn slash-command
   "Handler function for /slack/slash route"
   [system]
@@ -53,8 +63,8 @@
                :text text
                :local-time (java.time.LocalDateTime/now))
     (case text
-      "help" (response "")
-      :else (response "nothing to see here"))))
+      "help" (help-message)
+      (response "HELLOOOOO"))))
 
 ;; ------------------------------------------------------
 ;; Handler for OAuth redirection, installation in Slack

--- a/src/jcpsantiago/arqivist/api/slack/handlers.clj
+++ b/src/jcpsantiago/arqivist/api/slack/handlers.clj
@@ -45,10 +45,17 @@
    :body ""
    :headers {}})
 
+;;
 ;; ------------------------------------------------------
 ;; Handlers for Slack Slash commands
+;;
 
 (defn help-message
+  "
+  Creates a response with information on how to use The Arqivist.
+  Meant as the response to the `/arqive help` slash command + option,
+  as well as other interactions where the user must be reminded of how to use the app.
+  "
   []
   (-> (ui/help-message)
       json/write-value-as-string
@@ -56,18 +63,41 @@
       (content-type "application/json")))
 
 (defn slash-command
-  "Handler function for /slack/slash route"
-  [system]
-  (fn [{{{:keys [text response_url]} :form} :parameters :as request}]
+  "
+  Handler function for /slack/slash route.
+  This is the main entrypoint to the app's functionality.
+
+  Users will type `/arqive [options]` in Slack.
+  See j.a.a.s.specs ns for the request spec. 
+  "
+  [_]
+  (fn [{{{:keys [text]} :form} :parameters :as request}]
     (mulog/log ::handling-slack-slash-command
                :text text
                :local-time (java.time.LocalDateTime/now))
-    (case text
-      "help" (help-message)
-      (response "HELLOOOOO"))))
+    (let [first-word (re-find #"^\w+" text)]
+      ;; TODO: respond to empty `text` with a modal containing various options
+      (case first-word
+        "help" (help-message)
+        ;; TODO: add jobs handler
+        ;; "jobs" (list-jobs)
+        ;; TODO: add save once handler
+        ;; "once" (save-to-confluence request)
+        ;; TODO: add stop saving job handler
+        ;; "stop" (drop-job request)
+        ;; TODO: add save daily, etc job handler
+        ;; "daily" (save-continously request)
+        ;; TODO: add changelog handler
+        ;; "changelog" (changelog)
+        ;; TODO: if no match, respond with help message but explain there were no known keywords
+        (response (str "I'm sorry but I don't know what"
+                       " `" text "` " "means :sweat_smile:\nCheck the available commands with "
+                       "`/arqive help`"))))))
 
+;;
 ;; ------------------------------------------------------
 ;; Handler for OAuth redirection, installation in Slack
+;;
 ;; TODO: Add alerting system on errors
 (defn oauth-redirect
   "

--- a/src/jcpsantiago/arqivist/api/slack/router.clj
+++ b/src/jcpsantiago/arqivist/api/slack/router.clj
@@ -11,7 +11,8 @@
    * slash    — triggered after the user uses the `/arqive` slash command
    * redirect — called as part of the OAuth process at the end of installation"
   [system]
-  (let [wrap-verify-slack-request (partial middleware-arqivist/wrap-verify-slack-request (:slack-env system))]
+  (let [wrap-verify-slack-request (partial middleware-arqivist/wrap-verify-slack-request (:slack-env system))
+        wrap-add-slack-team-attributes (partial middleware-arqivist/wrap-add-slack-team-attributes (:db-connection system))]
     ["/slack"
      {:swagger {:tags ["Slack"]}}
      ["/shortcut"
@@ -32,14 +33,15 @@
       {:swagger {:externalDocs
                  {:description "Slack docs about Slash Commands"
                   :url "https://api.slack.com/interactivity/slash-commands"}}
-       :middleware [[wrap-verify-slack-request :verify-slack-request]]
+       :middleware [[wrap-verify-slack-request :verify-slack-request]
+                    [wrap-add-slack-team-attributes :add-slack-team-attributes]]
        :post
        {:summary "Target for Slash Command interactions"
         :description "This endpoint receives all interactions initiated by typing the `/arqive` slash command."
         :parameters {:header ::specs/request-header-attributes
                      :form ::specs/slash-form-params}
         :responses {200 {:body string?}}
-        :handler handlers/slash-command}}]
+        :handler (handlers/slash-command system)}}]
 
      ["/redirect"
       {:swagger {:externalDocs

--- a/src/jcpsantiago/arqivist/api/slack/specs.clj
+++ b/src/jcpsantiago/arqivist/api/slack/specs.clj
@@ -127,16 +127,21 @@
    :req-un [::x-slack-signature ::x-slack-request-timestamp]))
 
 ;; Internal representations ------------------------------------------------
-(spec/def ::uuid string?)
-(spec/def ::external_team_id string?)
-(spec/def ::team_name string?)
-(spec/def ::registering_user string?)
-(spec/def ::scopes string?)
-(spec/def ::access_token string?)
-(spec/def ::created_at string?)
-(spec/def ::atlassian_tenant_id integer?)
+(spec/def :slack_teams/:id pos-int?)
+(spec/def :slack_teams/:uuid uuid?)
+(spec/def :slack_teams/:app_id string?)
+(spec/def :slack_teams/:external_team_id string?)
+(spec/def :slack_teams/:team_name string?)
+(spec/def :slack_teams/:registering_user string?)
+(spec/def :slack_teams/:scopes string?)
+(spec/def :slack_teams/:access_token string?)
+(spec/def :slack_teams/:bot_user_id string?)
+(spec/def :slack_teams/:created_at inst?)
+(spec/def :slack_teams/:atlassian_tenant_id pos-int?)
 
 (spec/def ::team-attributes
   (spec/keys
-   :req-un [::id ::uuid ::app_id ::external_team_id ::team_name ::registering_user
-            ::scopes ::access_token ::bot_user_id ::created_at ::atlassian_tenant_id]))
+   :req [:slack_teams/:id :slack_teams/:uuid :slack_teams/:app_id 
+         :slack_teams/:external_team_id :slack_teams/:team_name 
+         :slack_teams/:registering_user :slack_teams/:scopes :slack_teams/:access_token 
+         :slack_teams/:bot_user_id :slack_teams/:created_at :slack_teams/:atlassian_tenant_id]))

--- a/src/jcpsantiago/arqivist/api/slack/specs.clj
+++ b/src/jcpsantiago/arqivist/api/slack/specs.clj
@@ -141,7 +141,7 @@
 
 (spec/def ::team-attributes
   (spec/keys
-   :req [:slack_teams/:id :slack_teams/:uuid :slack_teams/:app_id 
-         :slack_teams/:external_team_id :slack_teams/:team_name 
-         :slack_teams/:registering_user :slack_teams/:scopes :slack_teams/:access_token 
+   :req [:slack_teams/:id :slack_teams/:uuid :slack_teams/:app_id
+         :slack_teams/:external_team_id :slack_teams/:team_name
+         :slack_teams/:registering_user :slack_teams/:scopes :slack_teams/:access_token
          :slack_teams/:bot_user_id :slack_teams/:created_at :slack_teams/:atlassian_tenant_id]))

--- a/src/jcpsantiago/arqivist/api/slack/specs.clj
+++ b/src/jcpsantiago/arqivist/api/slack/specs.clj
@@ -22,6 +22,7 @@
 (spec/def ::id string?)
 (spec/def ::name string?)
 (spec/def ::token_type #{"bot" "user"})
+(spec/def ::text string?)
 
 ;; Error response
 (spec/def ::ok boolean?)
@@ -82,11 +83,23 @@
 ;; &user_id=U2147483697
 ;; &user_name=Steve
 ;; token=<alphanumerical string>
+(spec/def ::api_app_id string?)
+(spec/def ::trigger_id string?)
+(spec/def ::command non-blank-string?)
+(spec/def ::channel_id string?)
+(spec/def ::token string?)
+(spec/def ::channel_name string?)
+(spec/def ::user_id non-blank-string?)
+(spec/def ::user_name string?)
+(spec/def ::team_id string?)
+(spec/def ::team_domain string?)
+(spec/def ::response_url string?)
+(spec/def ::text string?)
+
 (spec/def ::slash-form-params
   (spec/keys
-   :req-un [::api_app_id ::trigger_id ::command ::channel_id ::token
-            ::channel_name ::user_id ::is_enterprise_install ::team_id
-            ::user_name ::team_domain ::response_url ::text]))
+   :req-un [::api_app_id ::trigger_id ::command ::channel_id ::token ::user_name
+            ::channel_name ::user_id ::team_id ::team_domain ::response_url ::text]))
 
 (spec/def ::shortcut-body
   (spec/keys
@@ -104,7 +117,16 @@
    :req-un [::type ::team ::user ::view]))
 
 ;; Internal representations ------------------------------------------------
+(spec/def ::uuid string?)
+(spec/def ::external_team_id string?)
+(spec/def ::team_name string?)
+(spec/def ::registering_user string?)
+(spec/def ::scopes string?)
+(spec/def ::access_token string?)
+(spec/def ::created_at string?)
+(spec/def ::atlassian_tenant_id integer?)
+
 (spec/def ::team-attributes
   (spec/keys
    :req-un [::id ::uuid ::app_id ::external_team_id ::team_name ::registering_user
-            ::scopes ::access_token ::bot_user_id ::created_at]))
+            ::scopes ::access_token ::bot_user_id ::created_at ::atlassian_tenant_id]))

--- a/src/jcpsantiago/arqivist/api/slack/ui_blocks.clj
+++ b/src/jcpsantiago/arqivist/api/slack/ui_blocks.clj
@@ -28,11 +28,6 @@
      {:type "mrkdwn",
       :text
       "*Use the _Archive thread_ action.* If you want to save a message thread as a Confluence page, select `Archive thread` in a message's context menu."}}
-    {:type "image",
-     :title {:type "plain_text", :text "image1", :emoji true},
-     :image_url
-     "https://api.slack.com/img/blocks/bkb_template_images/onboardingComplex.jpg",
-     :alt_text "image1"}
     {:type "divider"}
     {:type "context",
      :elements

--- a/src/jcpsantiago/arqivist/api/slack/ui_blocks.clj
+++ b/src/jcpsantiago/arqivist/api/slack/ui_blocks.clj
@@ -1,0 +1,40 @@
+(ns jcpsantiago.arqivist.api.slack.ui-blocks
+  "
+  Namespace with functions to build Slack UIs.
+  See https://api.slack.com/block-kit/building for the official documentation.
+  ")
+
+(defn help-message
+  "
+  Slack Block Kit representation of the response to /arqive help
+  "
+  []
+  {:blocks
+   [{:type "section",
+     :text
+     {:type "mrkdwn",
+      :text
+      "Hey there 👋 I'm The Arqivist. I'm here to help you save your Slack messages as Confluence pages and beyond.\nHere are the two main ways to do that:"}}
+    {:type "section",
+     :text {:type "mrkdwn", :text "*Use the `/arqive` slash command*"}}
+    {:type "context",
+     :elements
+     [{:type "mrkdwn",
+       :text
+       "👀 View all channels being archived with `/arqive jobs`\n✅ Save a channel once with `/arqive once`\n📓 Continuosly save the current channel with `/arqive daily [or weekly or monthly]`\n❌ Stop saving the current channel with `/arqive stop`"}]}
+    {:type "section", :text {:type "mrkdwn", :text " "}}
+    {:type "section",
+     :text
+     {:type "mrkdwn",
+      :text
+      "*Use the _Archive thread_ action.* If you want to save a message thread as a Confluence page, select `Archive thread` in a message's context menu."}}
+    {:type "image",
+     :title {:type "plain_text", :text "image1", :emoji true},
+     :image_url
+     "https://api.slack.com/img/blocks/bkb_template_images/onboardingComplex.jpg",
+     :alt_text "image1"}
+    {:type "divider"}
+    {:type "context",
+     :elements
+     [{:type "mrkdwn",
+       :text "❓ Get help at any time with `/arqive help`"}]}]})

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -20,17 +20,20 @@
    Needed to verify Slack requests."
   [handler id]
   (fn [request]
-    (let [raw-body (slurp (:body request))
-          request' (-> request
-                       (assoc :raw-body raw-body)
-                       (assoc :body (-> raw-body
-                                        (.getBytes "UTF-8")
-                                        java.io.ByteArrayInputStream.)))]
-      (mulog/log ::keeping-raw-json-string
-                 :middleware-id id
-                 :uri (:uri request)
-                 :local-time (java.time.LocalDateTime/now))
-      (handler request'))))
+    (if (and (:body request) (re-find #"slack" (:uri request)))
+      (let [raw-body (slurp (:body request))
+            request' (-> request
+                         (assoc :raw-body raw-body)
+                         (assoc :body (-> raw-body
+                                          (.getBytes "UTF-8")
+                                          java.io.ByteArrayInputStream.)))]
+        (mulog/log ::keeping-raw-json-string
+                   :middleware-id id
+                   :uri (:uri request)
+                   :local-time (java.time.LocalDateTime/now))
+        (handler request'))
+      ;; not a slack route with a body
+      (handler request))))
 
 (defn from-slack?
   "Verifies if the request really came from Slack.

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -6,6 +6,7 @@
    [buddy.core.keys :as keys]
    [buddy.sign.jws :as jws]
    [buddy.sign.jwt :as jwt]
+   [clojure.spec.alpha :as spec]
    [clojure.string :as string]
    [clojure.walk :refer [keywordize-keys]]
    [com.brunobonacci.mulog :as mulog]


### PR DESCRIPTION
📓 Description

_Summary of the change and link to any relevant tickets. New aliases should include details of why they are valuable_

Resolve #45 

This PR adds a handler for the `/arqive help` slash command. This response can be reused later for onboarding the users.

I'm also adding some more goodies into this one, because I did not have time to split into multiple PRs:
* adding slack team attributes to the request payload, so that downstream handlers have access to the info they need without coding IO for each of them
* switching to using `clj-slack` library instead of rolling our own slack api fns every time

:octocat: Type of change

- [x] New feature

:beetle: How Has This Been Tested?

- [ ] unit test
- [x] linter check
- [x] GitHub Action checkers

:eyes: Checklist

- [x] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [x] Add / update alias docs and README where relevant
- [x] Changelog entry describing notable changes
- [ ] Request maintainers review the PR
