### PR TITLE
dev: mkdocs Makefile targets for documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#43](https://github.com/jcpsantiago/thearqivist/issues/43) Add Confluence Get started page
 * dev: refactor slack verification middleware to keep the original body, plus parse header parameters
 * [#45](https://github.com/jcpsantiago/thearqivist/issues/45) Add help keyword to slash command
+* dev: mkdocs makefile targets for local documentation development
 
 ## 0.1.0 - 2023-04-20
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 
 # .PHONY: ensures target used rather than matching file name
 # https://makefiletutorial.com/#phony
-.PHONY: all lint deps dist pre-commit-check repl test test-ci test-watch clean
+.PHONY: all lint deps dist docs pre-commit-check repl test test-ci test-watch clean
 
 
 # ------- Makefile Variables --------- #
@@ -31,6 +31,9 @@
 
 # Column the target description is printed from
 HELP-DESCRIPTION-SPACING := 24
+
+## Tool commands
+MKDOCS_SERVER := mkdocs serve --dev-addr localhost:7777
 
 # Makefile file and directory name wildcard
 # EDN-FILES := $(wildcard *.edn)
@@ -153,6 +156,19 @@ lint-clean:  ## Clean MegaLinter report information
 
 # ------------------------------------ #
 
+# --- Documentation Generation  ------ #
+docs:  ## Build and run mkdocs in local server
+	$(info --------- Mkdocs Local Server ---------)
+	$(MKDOCS_SERVER)
+
+docs-changed:  ## Build only changed files and run mkdocs in local server
+	$(info --------- Mkdocs Local Server ---------)
+	$(MKDOCS_SERVER) --dirtyreload
+
+docs-build:  ## Build static docs locally
+	$(info --------- Mkdocs Local Server ---------)
+	mkdocs build
+# ------------------------------------ #
 
 # ------- Docker Containers ---------- #
 


### PR DESCRIPTION
📓 Description

Add  mkdocs Makefile targets for documentation

- `docs` build and serve documentation locally
- `docs-changed` only rebuild changed documents
- `docs-build` create static documentation locally

:octocat: Type of change

_Please tick `x` relevant options, delete those not relevant_

- [ ] New feature
- [ ] Deprecate feature
- [x] Development workflow
- [ ] Documentation
- [ ] Continuous integration workflow

:beetle: How Has This Been Tested?

- [ ] unit test
- [ ] linter check
- [x] GitHub Action checkers

:eyes: Checklist

- [x] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [ ] Add / update alias docs and README where relevant
- [x] Changelog entry describing notable changes
- [x] Request maintainers review the PR