### PR TITLE
Replace deprecated java-time with clojure.java-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Part of [#47](https://github.com/jcpsantiago/thearqivist/issues/47) Slack modal for `/arqive` slash command
 * Part of [#47](https://github.com/jcpsantiago/thearqivist/issues/47) Add modals for setting up and saving a channel
 * [#16](https://github.com/jcpsantiago/thearqivist/issues/16) Add specs and real-life examples of all Slack payloads
+* [#57](https://github.com/jcpsantiago/thearqivist/issues/57) Switch to clojure.java-time
 
 ## 0.1.0 - 2023-04-20
 

--- a/src/jcpsantiago/arqivist/api/confluence/utils.clj
+++ b/src/jcpsantiago/arqivist/api/confluence/utils.clj
@@ -8,7 +8,7 @@
    [buddy.sign.jwt :as jwt]
    [clojure.string :as string]
    [org.httpkit.client :as httpkit]
-   [java-time :as t]
+   [java-time.api :as java-time]
    [jsonista.core :as jsonista]
    [ring.util.codec :refer [url-encode]]))
 
@@ -57,16 +57,15 @@
   Calculates the JWT token for requests sent to Confluence.
   "
   [descriptor-key shared-secret canonical-method canonical-uri & [params]]
-  ;; FIXME: replace fns from java-time with something else (java-time is deprecated)
   (let [claims {:iss descriptor-key
-                :iat (-> (t/instant)
-                         t/to-millis-from-epoch
+                :iat (-> (java-time/instant)
+                         java-time/to-millis-from-epoch
                          (quot 1000))
                 :qsh (-> (atlassian-canonical-query-string canonical-method canonical-uri params)
                          atlassian-query-string-hash)
-                :exp (-> (t/instant)
-                         (t/plus (t/seconds 9000))
-                         t/to-millis-from-epoch
+                :exp (-> (java-time/instant)
+                         (java-time/plus (java-time/seconds 9000))
+                         java-time/to-millis-from-epoch
                          (quot 1000))}]
     (jwt/sign claims shared-secret {:alg :hs256 :header {:typ "JWT"}})))
 


### PR DESCRIPTION
📓 Description

_Summary of the change and link to any relevant tickets. New aliases should include details of why they are valuable_

Resolve #57 

:octocat: Type of change

_Please tick `x` relevant options, delete those not relevant_

- [ ] Switch dependency

:beetle: How Has This Been Tested?

- [x] unit test
- [x] linter check
- [x] GitHub Action checkers

:eyes: Checklist

- [x] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [ ] Add / update alias docs and README where relevant
- [x] Changelog entry describing notable changes
- [ ] Request maintainers review the PR
