### PR TITLE
Uninstall app from user's Slack when uninstalling from Confluence

### DIFF
--- a/.clj-kondo/com.github.seancorfield/next.jdbc/config.edn
+++ b/.clj-kondo/com.github.seancorfield/next.jdbc/config.edn
@@ -1,5 +1,8 @@
 {:hooks
  {:analyze-call
   {next.jdbc/with-transaction
-   hooks.com.github.seancorfield.next-jdbc/with-transaction}}
- :lint-as {next.jdbc/on-connection clojure.core/with-open}}
+   hooks.com.github.seancorfield.next-jdbc/with-transaction
+   next.jdbc/with-transaction+options
+   hooks.com.github.seancorfield.next-jdbc/with-transaction+options}}
+ :lint-as {next.jdbc/on-connection clojure.core/with-open
+           next.jdbc/on-connection+options clojure.core/with-open}}

--- a/.clj-kondo/com.github.seancorfield/next.jdbc/hooks/com/github/seancorfield/next_jdbc.clj_kondo
+++ b/.clj-kondo/com.github.seancorfield/next.jdbc/hooks/com/github/seancorfield/next_jdbc.clj_kondo
@@ -16,3 +16,19 @@
                      opts
                      body))]
       {:node new-node})))
+
+(defn with-transaction+options
+  "Expands (with-transaction+options [tx expr opts] body)
+  to (let [tx expr] opts body) per clj-kondo examples."
+  [{:keys [:node]}]
+  (let [[binding-vec & body] (rest (:children node))
+        [sym val opts] (:children binding-vec)]
+    (when-not (and sym val)
+      (throw (ex-info "No sym and val provided" {})))
+    (let [new-node (api/list-node
+                    (list*
+                     (api/token-node 'let)
+                     (api/vector-node [sym val])
+                     opts
+                     body))]
+      {:node new-node})))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#47](https://github.com/jcpsantiago/thearqivist/issues/47) Save channel `once`
 * Add `app.json` and define healthchecks for deployments with Dokku/Heroku
 * Correctly set the logging as pretty EDN for dev, and JSON for prod
+* Uninstall app from user's Slack if they uninstall from Confluence
 
 ## 0.1.0 - 2023-04-20
 

--- a/deps.edn
+++ b/deps.edn
@@ -42,7 +42,7 @@
  :aliases
  {;; Clojure.main execution of application
   :run/service
-  {:main-opts ["-m" "jcpsantiago.thearqivist"]}
+  {:main-opts ["-m" "jcpsantiago.arqivist.core"]}
 
   ;; Clojure.exec execution of specified function
   :run/greet

--- a/src/jcpsantiago/arqivist/api/confluence/handlers.clj
+++ b/src/jcpsantiago/arqivist/api/confluence/handlers.clj
@@ -216,7 +216,8 @@
                 (-> {:status 500 :body "Couldn't uninstall from Slack!"} (content-type "text-plain"))))))
 
         (catch Exception e
-                            ;; TODO: send a Slack message to the admin user informing them this failed, and they need to manually remove the app
+          ;; TODO: send a Slack message to the admin user informing them this failed,
+          ;; and they need to manually remove the app
           (mulog/log ::uninstalling-app
                      :success :false
                      :error (.getMessage e)

--- a/src/jcpsantiago/arqivist/api/confluence/handlers.clj
+++ b/src/jcpsantiago/arqivist/api/confluence/handlers.clj
@@ -169,59 +169,59 @@
 
     ;; drop the row corresponding to the current tenant, plus the row in 'slack_teams'
     (mulog/with-context {:slack-team-id external_team_id :slack-team-name team_name}
-      (try
-        (sql/delete! db-connection :atlassian_tenants {:id tenant_id})
-        (mulog/log ::atlassian-tenant-dropped-from-db
-                   :success :true
-                   :local-time (java.time.LocalDateTime/now))
+                        (try
+                          (sql/delete! db-connection :atlassian_tenants {:id tenant_id})
+                          (mulog/log ::atlassian-tenant-dropped-from-db
+                                     :success :true
+                                     :local-time (java.time.LocalDateTime/now))
 
-        (if (empty? slack_team)
-          ;; it's possible the user never connected their Slack workspace at all,
-          ;; in which case we don't need to do anything else
-          (response "OK")
+                          (if (empty? slack_team)
+                            ;; it's possible the user never connected their Slack workspace at all,
+                            ;; in which case we don't need to do anything else
+                            (response "OK")
 
-          ;; if there's a slack team connected, we have to uninstall the app
-          (let [res (-> @(httpkit/get
-                          (str "https://slack.com/api/apps.uninstall?"
-                               "client_id=" (get-in system [:slack-env :client-id])
-                               "&client_secret=" (get-in system [:slack-env :client-secret]))
-                          {:headers {"Content-Type" "application/json; charset=utf-8"}
-                           :oauth-token access_token})
-                        :body
-                        (jsonista/read-value jsonista/keyword-keys-object-mapper))]
+                            ;; if there's a slack team connected, we have to uninstall the app
+                            (let [res (-> @(httpkit/get
+                                            (str "https://slack.com/api/apps.uninstall?"
+                                                 "client_id=" (get-in system [:slack-env :client-id])
+                                                 "&client_secret=" (get-in system [:slack-env :client-secret]))
+                                            {:headers {"Content-Type" "application/json; charset=utf-8"}
+                                             :oauth-token access_token})
+                                          :body
+                                          (jsonista/read-value jsonista/keyword-keys-object-mapper))]
 
-            (cond
-              (spec/invalid? (spec/conform ::slack-specs/apps-uninstall res))
-              (do
-                (mulog/log ::uninstalled-from-slack
-                           :success :false
-                           :error "Slack API response did not conform to spec"
-                           :spec-explain (spec/explain ::slack-specs/apps-uninstall res)
-                           :local-time (java.time.LocalDateTime/now))
-                (-> {:status 500 :body "Couldn't uninstall from Slack, got invalid response"} (content-type "text-plain")))
+                              (cond
+                                (spec/invalid? (spec/conform ::slack-specs/apps-uninstall res))
+                                (do
+                                  (mulog/log ::uninstalled-from-slack
+                                             :success :false
+                                             :error "Slack API response did not conform to spec"
+                                             :spec-explain (spec/explain ::slack-specs/apps-uninstall res)
+                                             :local-time (java.time.LocalDateTime/now))
+                                  (-> {:status 500 :body "Couldn't uninstall from Slack, got invalid response"} (content-type "text-plain")))
 
-              (:ok res)
-              (do
-                (mulog/log ::uninstalled-from-slack
-                           :success :true
-                           :local-time (java.time.LocalDateTime/now))
-                (-> "OK" response (content-type "text/plain")))
+                                (:ok res)
+                                (do
+                                  (mulog/log ::uninstalled-from-slack
+                                             :success :true
+                                             :local-time (java.time.LocalDateTime/now))
+                                  (-> "OK" response (content-type "text/plain")))
 
-              :else
-              (do
-                (mulog/log ::uninstalled-from-slack
-                           :success :false
-                           :error (:error res)
-                           :local-time (java.time.LocalDateTime/now))
-                (-> {:status 500 :body "Couldn't uninstall from Slack!"} (content-type "text-plain"))))))
+                                :else
+                                (do
+                                  (mulog/log ::uninstalled-from-slack
+                                             :success :false
+                                             :error (:error res)
+                                             :local-time (java.time.LocalDateTime/now))
+                                  (-> {:status 500 :body "Couldn't uninstall from Slack!"} (content-type "text-plain"))))))
 
-        (catch Exception e
-          ;; TODO: send a Slack message to the admin user informing them this failed,
-          ;; and they need to manually remove the app
-          (mulog/log ::uninstalling-app
-                     :success :false
-                     :error (.getMessage e)
-                     :local-time (java.time.LocalDateTime/now)))))))
+                          (catch Exception e
+                            ;; TODO: send a Slack message to the admin user informing them this failed,
+                            ;; and they need to manually remove the app
+                            (mulog/log ::uninstalling-app
+                                       :success :false
+                                       :error (.getMessage e)
+                                       :local-time (java.time.LocalDateTime/now)))))))
 
 (defn lifecycle
   "
@@ -244,10 +244,10 @@
       (mulog/log ::lifecycle-event :event-type event-type :base-url base-url :local-time (java.time.LocalDateTime/now))
 
       (mulog/with-context {:base-url (:baseUrl lifecycle-payload) :event-type event-type :tenant-id id}
-        (case event-type
-          "installed" (installed lifecycle-payload atlassian_tenant system)
-          "enabled" (enabled lifecycle-payload atlassian_tenant system)
-          "uninstalled" (uninstalled lifecycle-payload atlassian_tenant system))))))
+                          (case event-type
+                            "installed" (installed lifecycle-payload atlassian_tenant system)
+                            "enabled" (enabled lifecycle-payload atlassian_tenant system)
+                            "uninstalled" (uninstalled lifecycle-payload atlassian_tenant system))))))
 
 (defn get-started
   "

--- a/src/jcpsantiago/arqivist/api/slack/specs.clj
+++ b/src/jcpsantiago/arqivist/api/slack/specs.clj
@@ -69,7 +69,7 @@
 (spec/def ::apps-uninstall
   (spec/or
    :good-response (spec/keys :req-un [::ok])
-   :error-response ::api-error))
+   :error-response ::error-response))
 
 ;; Slash commands are sent via POST requests with Content-type application/x-www-form-urlencoded.
 ;; See the docs in https://api.slack.com/interactivity/slash-commands#app_command_handling

--- a/src/jcpsantiago/arqivist/core.clj
+++ b/src/jcpsantiago/arqivist/core.clj
@@ -25,7 +25,7 @@
     (mulog/set-global-context!
      ;; TODO: get the version from a file or config, issue #23
      {:app-name "The Arqivist"
-      :version  "2023-11-14.2"
+      :version  "2023-11-17.1"
       :service-profile (System/getenv "ARQIVIST_SERVICE_PROFILE")})
     (mulog/log ::application-starup :arguments args)
     (if team

--- a/src/jcpsantiago/arqivist/core.clj
+++ b/src/jcpsantiago/arqivist/core.clj
@@ -25,7 +25,7 @@
     (mulog/set-global-context!
      ;; TODO: get the version from a file or config, issue #23
      {:app-name "The Arqivist"
-      :version  "2023-11-14.1"
+      :version  "2023-11-14.2"
       :service-profile (System/getenv "ARQIVIST_SERVICE_PROFILE")})
     (mulog/log ::application-starup :arguments args)
     (if team

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -194,7 +194,7 @@
       {:pairs [:content-type     (get-in request [:headers "content-type"])
                :content-encoding (get-in request [:headers "content-encoding"])
                :middleware       id]
-      ;; capture http status code from the response
+       ;; capture http status code from the response
        :capture (fn [{:keys [status]}] {:http-status status})}
       (handler request))))
 

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -137,6 +137,9 @@
                 (assoc :slack-team-attributes slack-team-attributes)
                 (assoc :slack-connection slack-connection)
                 handler))
+
+          ;; TODO: handle invalid spec explicitly
+
           (nil? (:token slack-connection))
           (do
             (mulog/log ::add-slack-team-attributes
@@ -188,12 +191,12 @@
     ;; track the request duration and outcome
     (mulog/trace
      :io.redefine.datawarp/http-request
-     {:pairs [:content-type     (get-in request [:headers "content-type"])
-              :content-encoding (get-in request [:headers "content-encoding"])
-              :middleware       id]
+      {:pairs [:content-type     (get-in request [:headers "content-type"])
+               :content-encoding (get-in request [:headers "content-encoding"])
+               :middleware       id]
       ;; capture http status code from the response
-      :capture (fn [{:keys [status]}] {:http-status status})}
-     (handler request))))
+       :capture (fn [{:keys [status]}] {:http-status status})}
+      (handler request))))
 
 ;; Atlassian middleware -----------------------------------------------------
 (defn verify-atlassian-iframe

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -191,12 +191,12 @@
     ;; track the request duration and outcome
     (mulog/trace
      :io.redefine.datawarp/http-request
-      {:pairs [:content-type     (get-in request [:headers "content-type"])
-               :content-encoding (get-in request [:headers "content-encoding"])
-               :middleware       id]
-       ;; capture http status code from the response
-       :capture (fn [{:keys [status]}] {:http-status status})}
-      (handler request))))
+     {:pairs [:content-type     (get-in request [:headers "content-type"])
+              :content-encoding (get-in request [:headers "content-encoding"])
+              :middleware       id]
+      ;; capture http status code from the response
+      :capture (fn [{:keys [status]}] {:http-status status})}
+     (handler request))))
 
 ;; Atlassian middleware -----------------------------------------------------
 (defn verify-atlassian-iframe


### PR DESCRIPTION
📓 Description

_Summary of the change and link to any relevant tickets. New aliases should include details of why they are valuable_

This PR updates the keys used to get env vars needed to call the `apps.uninstall` endpoint, which uninstall a Slack app.
We call this endpoint when the user triggers uninstallation from Confluence.

:octocat: Type of change

_Please tick `x` relevant options, delete those not relevant_

- [x] New feature

:beetle: How Has This Been Tested?

- [ ] unit test
- [x] linter check
- [x] GitHub Action checkers

:eyes: Checklist

- [x] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [ ] Add / update alias docs and README where relevant
- [x] Changelog entry describing notable changes
- [ ] Request maintainers review the PR
