### PR TITLE
Join slack channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Add `app.json` and define healthchecks for deployments with Dokku/Heroku
 * Correctly set the logging as pretty EDN for dev, and JSON for prod
 * Uninstall app from user's Slack if they uninstall from Confluence
+* [#88](https://github.com/jcpsantiago/thearqivist/issues/88) Automatically join public channels
 
 ## 0.1.0 - 2023-04-20
 

--- a/src/jcpsantiago/arqivist/api/slack/router.clj
+++ b/src/jcpsantiago/arqivist/api/slack/router.clj
@@ -36,7 +36,8 @@
                  {:description "Slack docs about Slash Commands"
                   :url "https://api.slack.com/interactivity/slash-commands"}}
        :middleware [[wrap-verify-slack-request :verify-slack-request]
-                    [wrap-add-slack-team-attributes :add-slack-team-attributes]]
+                    [wrap-add-slack-team-attributes :add-slack-team-attributes]
+                    [middleware-arqivist/wrap-join-slack-channel :join-slack-channel]]
        :post
        {:summary "Target for Slash Command interactions"
         :description "This endpoint receives all interactions initiated by typing the `/arqive` slash command."

--- a/src/jcpsantiago/arqivist/api/slack/specs.clj
+++ b/src/jcpsantiago/arqivist/api/slack/specs.clj
@@ -80,13 +80,15 @@
   (spec/coll-of ::channel))
 
 (spec/def ::users-conversations
-  (spec/keys
-   :req-un [::ok ::channels]))
+  (spec/or
+   :good-response (spec/keys :req-un [::ok ::channels])
+   :error-response ::error-response))
 
 ;; Conversations join API endpoint ------------------------------
 (spec/def ::conversations-join
-  (spec/keys
-   :req-un [::ok ::channel]))
+  (spec/or
+   :good-response (spec/keys :req-un [::ok ::channel])
+   :error-response ::error-response))
 
 ;; Slash commands are sent via POST requests with Content-type application/x-www-form-urlencoded.
 ;; See the docs in https://api.slack.com/interactivity/slash-commands#app_command_handling

--- a/src/jcpsantiago/arqivist/api/slack/specs.clj
+++ b/src/jcpsantiago/arqivist/api/slack/specs.clj
@@ -25,6 +25,10 @@
 (spec/def ::token_type #{"bot" "user"})
 (spec/def ::text string?)
 
+(spec/def ::channel
+  (spec/keys
+   :req-un [::id ::name]))
+
 ;; Error response
 (spec/def ::ok boolean?)
 (spec/def ::error string?)
@@ -70,6 +74,19 @@
   (spec/or
    :good-response (spec/keys :req-un [::ok])
    :error-response ::error-response))
+
+;; User conversations API endpoint ------------------------------
+(spec/def ::channels
+  (spec/coll-of ::channel))
+
+(spec/def ::users-conversations
+  (spec/keys
+   :req-un [::ok ::channels]))
+
+;; Conversations join API endpoint ------------------------------
+(spec/def ::conversations-join
+  (spec/keys
+   :req-un [::ok ::channel]))
 
 ;; Slash commands are sent via POST requests with Content-type application/x-www-form-urlencoded.
 ;; See the docs in https://api.slack.com/interactivity/slash-commands#app_command_handling

--- a/src/jcpsantiago/arqivist/core.clj
+++ b/src/jcpsantiago/arqivist/core.clj
@@ -25,7 +25,7 @@
     (mulog/set-global-context!
      ;; TODO: get the version from a file or config, issue #23
      {:app-name "The Arqivist"
-      :version  "2023-11-17.1"
+      :version  "2023-11-19.1"
       :service-profile (System/getenv "ARQIVIST_SERVICE_PROFILE")})
     (mulog/log ::application-starup :arguments args)
     (if team

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -273,7 +273,7 @@
         (do
           (mulog/log ::join-slack-channel
                      :success :false
-                     :error "Data does not conform to spec"
+                     :message "Data does not conform to spec"
                      :slack-error (:error users-conversations-response)
                      :explanation (spec/explain-data ::specs/users-conversations users-conversations-response));
           (response (error-response-text)))))))

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -188,6 +188,17 @@
 
     (some member-channels [channel-id])))
 
+(defn error-response-text
+  "
+  Returns a string with text for informing the user a generic error has happened.
+  Contains root-trace id from mulog.
+  "
+  []
+  (str "Something didn't work 😣\n"
+       "I've alerted my supervisor, and a fix will be deployed ASAP so please try again later.\n"
+       "In case the error persists, please contact supervisor@arqivist.app directly and share the "
+       "error code: `" (:mulog/root-trace (mulog/local-context)) "`."))
+
 (defn try-conversations-join
   "
   Helper function to the wrap-join-slack-channel middleware.
@@ -209,7 +220,7 @@
       (do
         (mulog/log ::try-conversations-join
                    :success :false
-                   :explanation "Possibly tried to join a private channel")
+                   :message "Possibly tried to join a private channel")
         (response
          (str "⚠️  It looks like you are trying to archive a *private channel*. "
               "Archived channels do not carry over permissions, so assume the contents of the archive will be public.\n"
@@ -221,14 +232,9 @@
       (do
         (mulog/log ::try-conversations-join
                    :success :false
-                   :error "conversations.join response does not conform to spec"
+                   :message "conversations.join response did not conform to spec"
                    :explanation (spec/explain-data ::specs/conversations-join conversations-join-response))
-        (response
-         ;; TODO: carve this out into a function
-         (str "Something didn't work 😣\n"
-              "I've alerted my supervisor, and a fix will be deployed ASAP so please try again later.\n"
-              "In case the error persists, please contact supervisor@arqivist.app directly and share the "
-              "error code: `" (:mulog/root-trace (mulog/local-context)) "`."))))))
+        (response (error-response-text))))))
 
 (defn wrap-join-slack-channel
   "
@@ -264,12 +270,7 @@
                      :error "Data does not conform to spec"
                      :slack-error (:error users-conversations-response)
                      :explanation (spec/explain-data ::specs/users-conversations users-conversations-response));
-          (response
-           ;; TODO: carve this out into a function
-           (str "Something didn't work 😣\n"
-                "I've alerted my supervisor, and a fix will be deployed ASAP so please try again later.\n"
-                "In case the error persists, please contact supervisor@arqivist.app directly and share the "
-                "error code: `" (:mulog/root-trace (mulog/local-context)) "`.")))))))
+          (response (error-response-text)))))))
 
 ;; Logging middleware -----------------------------------------------------
 ;; https://github.com/BrunoBonacci/mulog/blob/master/doc/ring-tracking.md

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -180,7 +180,13 @@
                    :error (.getMessage e)
                    :local-time (java.time.LocalDateTime/now))))))
 
+;; Utils and handler for "join slack channel" middleware --- ↓
+
 (defn conversation-member?
+  "
+  Util fn that checks if a channel-id is in the list of channels (aka conversations)
+  a user is in, as returned from the users.conversations Slack API method.
+  "
   [channel-id user-conversations]
   (let [member-channels (->> (:channels user-conversations)
                              (map :id)

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -246,9 +246,9 @@
   "
   Ring middleware which checks if The Arqivist bot is a member of a channel,
   then joins the channel, or asks the user to invite the bot in case it's a private channel.
-  Used when interacting with the slash command endpoint.
 
-  !! Must run _after_ the wrap-add-slack-team-attributes middleware to access slack-connection!!
+  * Must run _after_ the wrap-add-slack-team-attributes middleware to access slack-connection
+  * Used when interacting with the slash command endpoint.
   "
   [handler _]
   (fn [request]

--- a/src/jcpsantiago/arqivist/middleware.clj
+++ b/src/jcpsantiago/arqivist/middleware.clj
@@ -292,12 +292,12 @@
     ;; track the request duration and outcome
     (mulog/trace
      :io.redefine.datawarp/http-request
-      {:pairs [:content-type     (get-in request [:headers "content-type"])
-               :content-encoding (get-in request [:headers "content-encoding"])
-               :middleware       id]
+     {:pairs [:content-type     (get-in request [:headers "content-type"])
+              :content-encoding (get-in request [:headers "content-encoding"])
+              :middleware       id]
       ;; capture http status code from the response
-       :capture (fn [{:keys [status]}] {:http-status status})}
-      (handler request))))
+      :capture (fn [{:keys [status]}] {:http-status status})}
+     (handler request))))
 
 ;; Atlassian middleware -----------------------------------------------------
 (defn verify-atlassian-iframe


### PR DESCRIPTION
📓 Description

_Summary of the change and link to any relevant tickets. New aliases should include details of why they are valuable_

Resolve #88 

This PR addds a new middleware which checks if the bot is a member of the channel from where the `/slash` command originates, and tries to join if it is not a member yet. If the channel is private, the middleware responds with a message to the user informing them they may make the private contents public, and if that's ok ask them to invite the bot into the channel and try again.

:octocat: Type of change

_Please tick `x` relevant options, delete those not relevant_

- [x] New feature

:beetle: How Has This Been Tested?

- [ ] unit test
- [x] linter check
- [x] GitHub Action checkers

:eyes: Checklist

- [x] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [ ] Add / update alias docs and README where relevant
- [x] Changelog entry describing notable changes
- [x] Request maintainers review the PR
