### PR TITLE
dev: update hack locally details for starting a REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Correctly set the logging as pretty EDN for dev, and JSON for prod
 * Uninstall app from user's Slack if they uninstall from Confluence
 * [#88](https://github.com/jcpsantiago/thearqivist/issues/88) Automatically join public channels
+* dev: update hack locally details for starting a REPL
 
 ## 0.1.0 - 2023-04-20
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ After installing The Arqivist in Slack, you can interact with the bot in two way
 ## Hacking locally
 
 * Start a Postgres instance with `docker compose up -d postgres`
-* Start a REPL with `make repl`
+* Start a REPL with either:
+    * `make repl` rich REPL prompt (requires [Practicalli Clojure CLI Config](https://practical.li/clojure/clojure-cli/practicalli-config/)) 
+    * `clj -A:dev/env` for a basic repl prompt
 * Start the system with `(start)` in the Clojure REPL
 * `make lint` to check for format and lint issue, `make lint-fix` to automatically fix them (stage or commit other changes first) - requires node.js locally
 

--- a/deps.edn
+++ b/deps.edn
@@ -49,6 +49,13 @@
   {:exec-fn jcpsantiago.thearqivist/greet
    :exec-args {:name "Clojure"}}
 
+  ;; Add libraries and paths to support local development
+  :dev/env
+  {:extra-paths ["dev" "test"]
+   :extra-deps
+   {djblue/portal                {:mvn/version "0.49.0"}
+    org.clojure/tools.namespace  {:mvn/version "1.4.4"}}}
+
   ;; Add libraries and paths to support additional test tools
   :test/env
   {}


### PR DESCRIPTION
📓 Description

Update hacking locally instructions when starting a repl, highlighing a dependency on [Practicalli Clojure CLI Config](https://practical.li/clojure/clojure-cli/practicalli-config/) or using `clj` as a basic alternative

- add `:dev/env` alias to `deps.ed` to include `dev` and `test` paths, extra dependencies for `portal` and `tools.namespace`

- update `README.md` with `clj` command details

:octocat: Type of change

_Please tick `x` relevant options, delete those not relevant_

- [ ] New feature
- [ ] Deprecate feature
- [ ] Development workflow
- [X] Documentation
- [ ] Continuous integration workflow

:beetle: How Has This Been Tested?

- [ ] unit test
- [X] linter check
- [X] GitHub Action checkers

:eyes: Checklist

- [X] Code follows the [Practicalli cljstyle configuration](https://practical.li/clojure/clojure-cli/clojure-style/#cljstyle)
- [X] Add / update alias docs and README where relevant
- [X] Changelog entry describing notable changes
- [x] Request maintainers review the PR